### PR TITLE
Fix invalid long_description in setup.py

### DIFF
--- a/faiss/python/setup.py
+++ b/faiss/python/setup.py
@@ -98,7 +98,7 @@ if found_faiss_example_external_module_lib:
 long_description = """
 Faiss is a library for efficient similarity search and clustering of dense
 vectors. It contains algorithms that search in sets of vectors of any size,
- up to ones that possibly do not fit in RAM. It also contains supporting
+up to ones that possibly do not fit in RAM. It also contains supporting
 code for evaluation and parameter tuning. Faiss is written in C++ with
 complete wrappers for Python/numpy. Some of the most useful algorithms
 are implemented on the GPU. It is developed by Facebook AI Research.
@@ -108,6 +108,7 @@ setup(
     version="1.11.0",
     description="A library for efficient similarity search and clustering of dense vectors",
     long_description=long_description,
+    long_description_content_type="text/plain",
     url="https://github.com/facebookresearch/faiss",
     author="Matthijs Douze, Jeff Johnson, Herve Jegou, Lucas Hosseini",
     author_email="faiss@meta.com",


### PR DESCRIPTION
Fix unexpected indentation in long description in `setup.py` and set long description content type to `text/plain`.
Fixes wheel validation error and warning from `twine check` command and `pypa/gh-action-pypi-publish@release/v1` action.
I need it for my custom Faiss build which I upload to a private registry (cannot use Conda unfortunately). Currently I'm patching this myself, but I believe there is no reason not to upstream it.

```
$ twine check dist/*
Checking dist/faiss_cpu-1.7.2-cp310-cp310-linux_x86_64.whl: FAILED
ERROR    `long_description` has syntax errors in markup and would not be        
         rendered on PyPI.                                                      
         line 4: Error: Unexpected indentation.                                 
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.
```

After changes:
```
Checking dist/faiss_cpu-1.7.2-cp310-cp310-linux_x86_64.whl: PASSED
```